### PR TITLE
Make sure the base url is set when calling authenticate_request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.14.0] - 2024-02-14
+
+### Changed
+
+- Make sure the base_url is set when calling authenticate_request. [#27](https://github.com/microsoft/kiota-http-ruby/pull/27)
+
 ## [0.13.0] - 2024-02-05
 
 ### Changed

--- a/lib/microsoft_kiota_faraday/version.rb
+++ b/lib/microsoft_kiota_faraday/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MicrosoftKiotaFaraday
-  VERSION = '0.13.0'
+  VERSION = '0.14.0'
 end


### PR DESCRIPTION
This is a fix for the issue where the base url was not being set when calling authenticate_request.It caused an error later in the `microsoft_kiota_authentication_oauth ` gem. The crux of the problem goes like that:
- The `request_info` is passed to the `access_token_provider` and `request_info.uri` is used to build the request [here](https://github.com/microsoft/kiota-abstractions-ruby/blob/7367a156276923eddd22e52335adbba88b1bf71e/lib/microsoft_kiota_abstractions/authentication/base_bearer_token_authentication_provider.rb#L21). This `uri` is missing the base url.
- The uri is then parsed [here](https://github.com/microsoft/kiota-authentication-oauth-ruby/blob/69ebeb6705b1d621a9943a15d634e9a33c77d23e/lib/microsoft_kiota_authentication_oauth/oauth_access_token_provider.rb#L54) and an error is raised if `scheme` is not `https`. Because the base url is missing, the URI is only parsed as a relative path and thus always fails the scheme check.

The fix is to always make sure we set the `baseurl` before calling action where the url might be templated. The fix is inspired from the [Csharp version](https://github.com/microsoft/kiota-http-dotnet/blob/119e79cf50dcb94770ba3942ff13e1e9ab57bf8e/src/HttpClientRequestAdapter.cs#L515-L518) of the class.

I tried adding some kind of test, but there almost nothing already in place and to test my small fix, I would have to either mock or instantiate a dozen of classes which some are not even in the same gem 😢.