### PR TITLE
Ensure get_parse_node does not fail when response body is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+## [0.15.0] - 2024-02-16
+
+### Changed
+
+- Ensure get_parse_node does not fail when response body is empty. [#27](https://github.com/microsoft/kiota-http-ruby/pull/28)
+
 ## [0.14.0] - 2024-02-14
 
 ### Changed

--- a/lib/microsoft_kiota_faraday/faraday_request_adapter.rb
+++ b/lib/microsoft_kiota_faraday/faraday_request_adapter.rb
@@ -71,6 +71,7 @@ module MicrosoftKiotaFaraday
       raise StandardError, 'response cannot be null' unless response
       response_content_type = self.get_response_content_type(response);
       raise StandardError, 'no response content type found for deserialization' unless response_content_type
+      return if response.body.nil? || response.body.empty?
       return @parse_node_factory.get_parse_node(response_content_type, response.body)
     end
 

--- a/lib/microsoft_kiota_faraday/version.rb
+++ b/lib/microsoft_kiota_faraday/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MicrosoftKiotaFaraday
-  VERSION = '0.14.0'
+  VERSION = '0.15.0'
 end

--- a/spec/microsoft_kiota_faraday/faraday_request_adapter_spec.rb
+++ b/spec/microsoft_kiota_faraday/faraday_request_adapter_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+RSpec.describe MicrosoftKiotaFaraday::FaradayRequestAdapter do
+  subject(:adapter) { described_class.new(authentication_provider) }
+
+  let(:authentication_provider) { double("authentication_provider") }
+  let(:headers) { { 'content-type' => 'application/json' } }
+  let(:body) { { key: "value" }.to_json }
+
+  describe "#get_root_parse_node" do
+    context "when response is null" do
+      it "raises an error" do
+        expect { adapter.get_root_parse_node(nil) }.to raise_error(StandardError, 'response cannot be null')
+      end
+    end
+
+    context "when response content type is not found" do
+      let(:response) { instance_double(Faraday::Response, body:, headers: {}) }
+
+      it "raises an error" do
+        expect { adapter.get_root_parse_node(response) }.to raise_error(StandardError, 'no response content type found for deserialization')
+      end
+    end
+
+    context "when response body is nil" do
+      let(:response) { instance_double(Faraday::Response, body: nil, headers:) }
+
+      it "returns nil" do
+        expect(adapter.get_root_parse_node(response)).to be_nil
+      end
+    end
+
+    context "when response body is empty" do
+      let(:response) { instance_double(Faraday::Response, body: "", headers:) }
+
+      it "returns nil" do
+        expect(adapter.get_root_parse_node(response)).to be_nil
+      end
+    end
+
+    context "when response body is not nil" do
+      subject(:adapter) { described_class.new(authentication_provider, parse_node_factory) }
+
+      let(:response) { instance_double(Faraday::Response, body:, headers:) }
+      let(:parse_node_factory) { double("parse_node_factory") }
+      let(:parse_node) { double("parse_node") }
+
+      before do
+        allow(parse_node_factory).to receive(:get_parse_node).with("application/json", body).and_return(parse_node)
+      end
+
+      it "returns the parse node" do
+        expect(adapter.get_root_parse_node(response)).to eq(parse_node)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Guard against empty response body causing an error when finding the parse node.

I added some specs.

closes #26