### PR TITLE
fix: update minimum required ruby version to 3.3.0

### DIFF
--- a/microsoft_kiota_faraday.gemspec
+++ b/microsoft_kiota_faraday.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
     'source_code_uri' => 'https://github.com/microsoft/kiota-http-ruby',
     'github_repo'     => 'ssh://github.com/microsoft/kiota-http-ruby'
   }
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.3.0"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
Updates the required Ruby version in the gemspec from >= 3.0.0 to >= 3.3.0.