### PR TITLE
fix: update microsoft_kiota_abstractions dependency to 0.15.1

### DIFF
--- a/microsoft_kiota_faraday.gemspec
+++ b/microsoft_kiota_faraday.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'microsoft_kiota_abstractions', '>= 0.14', '< 0.16'
+  spec.add_runtime_dependency 'microsoft_kiota_abstractions', '~> 0.15', '>= 0.15.1'
   spec.add_runtime_dependency 'faraday', '~> 2.7', '>= 2.7.2'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Updates the microsoft_kiota_abstractions dependency to 0.15.1