### PR TITLE
chore: bump microsoft_kiota_abstractions upper bound to < 0.17

### DIFF
--- a/microsoft_kiota_faraday.gemspec
+++ b/microsoft_kiota_faraday.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'bin'
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency 'microsoft_kiota_abstractions', '>= 0.14', '< 0.16'
+  spec.add_runtime_dependency 'microsoft_kiota_abstractions', '>= 0.14', '< 0.17'
   spec.add_runtime_dependency 'faraday', '~> 2.7', '>= 2.7.2'
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Allow compatibility with kiota-abstractions-ruby 0.16.0 which adds composed type support (ParseNodeHelper, write_object_value variadic).